### PR TITLE
Replace Code for IBM i `onEvent` by `subscribe`

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16,7 +16,7 @@
         "tmp": "^0.2.1"
       },
       "devDependencies": {
-        "@halcyontech/vscode-ibmi-types": "^2.10.1",
+        "@halcyontech/vscode-ibmi-types": "^2.12",
         "@types/glob": "^7.2.0",
         "@types/mocha": "^9.1.1",
         "@types/node": "16.x",
@@ -534,11 +534,10 @@
       }
     },
     "node_modules/@halcyontech/vscode-ibmi-types": {
-      "version": "2.11.0",
-      "resolved": "https://registry.npmjs.org/@halcyontech/vscode-ibmi-types/-/vscode-ibmi-types-2.11.0.tgz",
-      "integrity": "sha512-CCk/9rihuEeO3OK9FcHBtEplmOqX0wgYmnVHaLYdsWwmc7M4PYAf5gqwV2pzn0JJYW1LP/NX1oLc1vwKTm4x7g==",
-      "dev": true,
-      "license": "ISC"
+      "version": "2.12.1",
+      "resolved": "http://rdanart01plv.quarcad.net:4873/@halcyontech%2fvscode-ibmi-types/-/vscode-ibmi-types-2.12.1.tgz",
+      "integrity": "sha512-28OUrucjb98bo28KrEbw0xMr00BZ9RWLbXhAW4kapcZ7CNhrOIIZg/LlP+LjVzfJ97i+XyhdCF1es2+2oFMdXg==",
+      "dev": true
     },
     "node_modules/@humanwhocodes/config-array": {
       "version": "0.11.14",

--- a/package.json
+++ b/package.json
@@ -415,7 +415,7 @@
     "test": "node ./out/test/runTest.js"
   },
   "devDependencies": {
-    "@halcyontech/vscode-ibmi-types": "^2.10.1",
+    "@halcyontech/vscode-ibmi-types": "^2.12",
     "@types/glob": "^7.2.0",
     "@types/mocha": "^9.1.1",
     "@types/node": "16.x",

--- a/src/SpooledFileBrowser.ts
+++ b/src/SpooledFileBrowser.ts
@@ -1,15 +1,15 @@
 /* eslint-disable @typescript-eslint/naming-convention */
+import { FocusOptions } from '@halcyontech/vscode-ibmi-types/';
 import fs from "fs";
 import os from "os";
-import util from "util";
 import path from "path";
+import util from "util";
 import vscode, { l10n, } from 'vscode';
-import { Code4i, getInstance, makeid, findExistingDocumentUri } from "./tools";
-import { IBMiSpooledFile, SplfDefaultOpenMode, SplfOpenOptions } from './typings';
-import { IBMiContentSplf } from "./api/IBMiContentSplf";
-import SPLFBrowser, { SpooledFileUser, UserSpooledFiles } from './views/userSplfsView';
 import { SplfFS, getUriFromPath_Splf, parseFSOptions } from "../src/filesystem/qsys/SplfFs";
-import { FocusOptions } from '@halcyontech/vscode-ibmi-types/';
+import { IBMiContentSplf } from "./api/IBMiContentSplf";
+import { Code4i, findExistingDocumentUri, getInstance, makeid } from "./tools";
+import { IBMiSpooledFile, SplfDefaultOpenMode, SplfOpenOptions } from './typings';
+import SPLFBrowser, { SpooledFileUser, UserSpooledFiles } from './views/userSplfsView';
 
 const writeFileAsync = util.promisify(fs.writeFile);
 
@@ -101,7 +101,7 @@ export function initializeSpooledFileBrowser(context: vscode.ExtensionContext) {
           removeUser = removeUser.trim();
           let message = l10n.t(`Are you sure you want to delete the user spooled file filter,'{0}'?`, removeUser);
           let detail = ``;
-          vscode.window.showWarningMessage(message, {modal:true, detail},l10n.t(`Yes`), l10n.t(`No`))
+          vscode.window.showWarningMessage(message, { modal: true, detail }, l10n.t(`Yes`), l10n.t(`No`))
             .then(async result => {
               if (result === l10n.t(`Yes`)) {
                 const inx = usersSpooledFile.indexOf(removeUser);
@@ -148,10 +148,10 @@ export function initializeSpooledFileBrowser(context: vscode.ExtensionContext) {
         const config = getConfig();
         //Running from right click
 
-        const message = l10n.t('Are you sure you want to delete {0}?',node.path);
-        const detail = undefined ;
-      // let result = await vscode.window.showWarningMessage(l10n.t(`Are you sure you want to delete spooled file {0}?`, node.path), l10n.t(`Yes`), l10n.t(`Cancel`));
-        let result = await vscode.window.showWarningMessage(message, { modal: true, detail }, l10n.t(`Yes`),l10n.t(`Cancel`));
+        const message = l10n.t('Are you sure you want to delete {0}?', node.path);
+        const detail = undefined;
+        // let result = await vscode.window.showWarningMessage(l10n.t(`Are you sure you want to delete spooled file {0}?`, node.path), l10n.t(`Yes`), l10n.t(`Cancel`));
+        let result = await vscode.window.showWarningMessage(message, { modal: true, detail }, l10n.t(`Yes`), l10n.t(`Cancel`));
 
         if (result === `Yes`) {
 
@@ -186,7 +186,7 @@ export function initializeSpooledFileBrowser(context: vscode.ExtensionContext) {
         let deleteCount = 0;
         let message = l10n.t(`Are you sure you want to delete ALL spooled files named {0}?`, node.name);
         let detail = ``;
-        let result = await vscode.window.showWarningMessage(message, {modal:true, detail}, l10n.t(`Yes`), l10n.t(`No`));
+        let result = await vscode.window.showWarningMessage(message, { modal: true, detail }, l10n.t(`Yes`), l10n.t(`No`));
 
         if (result === `Yes`) {
           const connection = getConnection();
@@ -253,7 +253,7 @@ export function initializeSpooledFileBrowser(context: vscode.ExtensionContext) {
         let deleteCount = 0;
         let message = l10n.t(`Are you sure you want to delete ALL spooled files filtered by value {1}?`, node.name, node.parent.filter);
         let detail = ``;
-        let result = await vscode.window.showWarningMessage(message, {modal:true, detail}, l10n.t(`Yes`), l10n.t(`No`));
+        let result = await vscode.window.showWarningMessage(message, { modal: true, detail }, l10n.t(`Yes`), l10n.t(`No`));
 
         if (result === `Yes`) {
           const connection = getConnection();
@@ -319,7 +319,7 @@ export function initializeSpooledFileBrowser(context: vscode.ExtensionContext) {
         //Running from right click
         let message = l10n.t(`Are you sure you want to delete ALL spooled files for user {0}?`, node.user);
         let detail = ``;
-        let result = await vscode.window.showWarningMessage(message, {modal:true, detail}, l10n.t(`Yes`), l10n.t(`No`));
+        let result = await vscode.window.showWarningMessage(message, { modal: true, detail }, l10n.t(`Yes`), l10n.t(`No`));
 
         if (result === `Yes`) {
 
@@ -393,7 +393,7 @@ export function initializeSpooledFileBrowser(context: vscode.ExtensionContext) {
         searchUser = node.user;
       }
 
-      if (!searchUser) {return;}
+      if (!searchUser) { return; }
 
       searchTerm = await vscode.window.showInputBox({
         // prompt: `Filter ${searchUser}'s spooled files. Delete value to clear filter.`,
@@ -480,7 +480,7 @@ export function initializeSpooledFileBrowser(context: vscode.ExtensionContext) {
           if (process.platform === `win32`) {
             //Issue with getFile not working propertly on Windows
             //when there was a / at the start.
-            if (localPath[0] === `/`) {localPath = localPath.substring(1);}
+            if (localPath[0] === `/`) { localPath = localPath.substring(1); }
           }
           try {
             let fileEncoding: BufferEncoding | null = `utf8`;
@@ -536,7 +536,7 @@ export function initializeSpooledFileBrowser(context: vscode.ExtensionContext) {
     })
 
   );
-  getInstance()?.onEvent(`connected`, run_on_connection);
+  getInstance()?.subscribe(context, `connected`, "Refresh spooled file browser", run_on_connection);
 }
 
 function getConfig() {

--- a/src/SpooledFileSearchResults.ts
+++ b/src/SpooledFileSearchResults.ts
@@ -1,8 +1,8 @@
 import vscode, { l10n, } from 'vscode';
-import { Code4i, getInstance } from "./tools";
-import { UserSplfSearch } from './api/spooledFileSearch';
-import { UserSplfSearchView } from './views/userSplfsSearchView';
 import { IBMiContentSplf } from "./api/IBMiContentSplf";
+import { UserSplfSearch } from './api/spooledFileSearch';
+import { Code4i, getInstance } from "./tools";
+import { UserSplfSearchView } from './views/userSplfsSearchView';
 // import setSearchResults from "@halcyontech/vscode-ibmi-types/instantiate";
 
 interface SearchParms {
@@ -20,12 +20,12 @@ export async function initializeSpooledFileSearchView(context: vscode.ExtensionC
   context.subscriptions.push(
     vscode.commands.registerCommand(`vscode-ibmi-splfbrowser.searchSpooledFiles`, async (node) => {
       //Initiate search from Spooled file item
-      if (node && (/^spooledfile/.test( node.contextValue))) {
+      if (node && (/^spooledfile/.test(node.contextValue))) {
         search.user = node.user;
         search.name = node.name;
         search.word = node.parent.filter;
       }//Initiate search from user filter
-      else if (node && (/^splfuser/.test( node.contextValue))) {
+      else if (node && (/^splfuser/.test(node.contextValue))) {
         search.user = node.user;
       }
       if (!search.user) {
@@ -47,7 +47,7 @@ export async function initializeSpooledFileSearchView(context: vscode.ExtensionC
       // if (!search.name) {return;}
 
       search.term = await vscode.window.showInputBox({
-        prompt: l10n.t(`Search in spooled files named {0}`,search.name)
+        prompt: l10n.t(`Search in spooled files named {0}`, search.name)
       });
 
       if (search.term) {
@@ -57,20 +57,20 @@ export async function initializeSpooledFileSearchView(context: vscode.ExtensionC
             title: l10n.t(`Searching`),
           }, async progress => {
             progress.report({
-              message: l10n.t(`'{0}' in {1}, {2} spooled files.`,search.term,search.user,search.name)
+              message: l10n.t(`'{0}' in {1}, {2} spooled files.`, search.term, search.user, search.name)
             });
             const splfnum = await IBMiContentSplf.getUserSpooledFileCount(search.user, search.name);
             if (Number(splfnum) > 0) {
               // NOTE: if more messages are added, lower the timeout interval
               const timeoutInternal = 9000;
               const searchMessages = [
-                l10n.t(`'{0}' in {1} spooled files.`,search.term,search.name),
-                l10n.t(`This is taking a while because there are {0} spooled files. Searching '{1}' in {2} still.`,splfnum,search.term,search.user),
-                l10n.t(`What's so special about '{0}' anyway?`,search.term),
-                l10n.t(`Still searching '{0}' in {1}...`,search.term,search.user),
+                l10n.t(`'{0}' in {1} spooled files.`, search.term, search.name),
+                l10n.t(`This is taking a while because there are {0} spooled files. Searching '{1}' in {2} still.`, splfnum, search.term, search.user),
+                l10n.t(`What's so special about '{0}' anyway?`, search.term),
+                l10n.t(`Still searching '{0}' in {1}...`, search.term, search.user),
                 l10n.t(`Wow. This really is taking a while. Let's hope you get the result you want.`),
-                l10n.t(`How does one end up with {0} spooled files.  Ever heard of cleaning up?`,splfnum),
-                l10n.t(`'{0}' in {1}.`,search.term,search.user),
+                l10n.t(`How does one end up with {0} spooled files.  Ever heard of cleaning up?`, splfnum),
+                l10n.t(`'{0}' in {1}.`, search.term, search.user),
               ];
               let currentMessage = 0;
               const messageTimeout = setInterval(() => {
@@ -95,11 +95,11 @@ export async function initializeSpooledFileSearchView(context: vscode.ExtensionC
                 results = results.sort((a, b) => {
                   return a.path.localeCompare(b.path);
                 });
-                setSearchResultsSplf(`searchUserSpooledFiles`,search.term, results);
+                setSearchResultsSplf(`searchUserSpooledFiles`, search.term, results);
                 // setSearchResults(search.term, results.sort((a, b) => a.path.localeCompare(b.path)));
 
               } else {
-                vscode.window.showInformationMessage(l10n.t(`No results found searching for '{0}' in {1}.`, search.term,search.name));
+                vscode.window.showInformationMessage(l10n.t(`No results found searching for '{0}' in {1}.`, search.term, search.name));
               }
             } else {
               vscode.window.showErrorMessage(l10n.t(`No spooled files to search.`));
@@ -115,7 +115,7 @@ export async function initializeSpooledFileSearchView(context: vscode.ExtensionC
     }),
     vscode.window.registerTreeDataProvider(`UserSplfSearchView`, userSplfSearchViewProvider),
   );
-  getInstance()?.onEvent(`connected`, runOnConnection );
+  getInstance()?.subscribe(context, `connected`, "Get temporary library", runOnConnection);
 }
 
 function getConfig() {
@@ -151,7 +151,7 @@ function getContent() {
 // let userSplfSearchViewProvider = <UserSplfSearchView>{};
 export function setSearchResultsSplf(actionCommand: string, term: string, results: UserSplfSearch.Result[]) {
   userSplfSearchViewProvider.setResults(actionCommand, term, results);
-} 
+}
 
 async function runOnConnection(): Promise<void> {
   const library = Code4i.getTempLibrary();


### PR DESCRIPTION
Since Code for IBM i v2.12, the `onEvent` method has been deprecated (and will be removed in v3.0) and must be replaced by `subscribe`.

This PR takes care of this replacement.